### PR TITLE
fix(null): ensure val != null

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -454,7 +454,7 @@ class Table extends SQLBase {
         const value = row.block.cid
         let val = row.getIndex(i)
         let path
-        while (typeof val === 'object') {
+        while (typeof val === 'object' && val != null) {
           path = val.path
           const block = await get(val.link)
           row = await this.createRow({ block })


### PR DESCRIPTION
null is also an object, so need an extra check here in some cases. I found this little nit when importing a csv via the cli tool. this is against current master (not npm release).

```
node --version
v14.15.1
```
System Software Overview:
```
System Version: macOS 11.1 (20C69)
Kernel Version: Darwin 20.2.0
Boot Volume: Macintosh HD
Boot Mode: Normal
...
Secure Virtual Memory: Enabled
System Integrity Protection: Enabled
Time since boot: 34 days 2:14
```